### PR TITLE
Add documentation for the color settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Screenshot:
 
 ## Settings
 
+> `"bracket-pair-colorizer-2.colors"`  
+Define the colors used to colorize brackets. Accepts valid color names, hex codes, and `rgba()` values. Default:  
+```json
+"bracket-pair-colorizer-2.colors": [
+    "Gold",
+    "Orchid",
+    "LightSkyBlue"
+]
+```
+
 > `"bracket-pair-colorizer-2.forceUniqueOpeningColor"`  
 ![Disabled](images/forceUniqueOpeningColorDisabled.png "forceUniqueOpeningColor Disabled")
 ![Enabled](images/forceUniqueOpeningColorEnabled.png "forceUniqueOpeningColor Enabled")


### PR DESCRIPTION
Adds the `bracket-pair-colorizer-2.colors` setting to the readme file.

Related: #24.