### PR TITLE
Update README.MD to reflect opacity settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Should the currently scoped brackets always be highlighted?
 Choose a border style to highlight the active scope. Use `{color}` to match the existing bracket color  
 It is recommended to disable the inbuilt `editor.matchBrackets` setting if using this feature  
 ![BorderStyle](images/activeScopeBorder.png "Active Scope Border Example")  
->Tip: Add the value `"backgroundColor : {color}"` to increase visibility  
+>Tip: Add the value `"backgroundColor : {color}"` to increase visibility. The example below shows a opaque background color, by default adding the aforementioned value will set opacity to 1. To set your own opacity value please use: `"backgroundColor : {color}; opacity: 0.33"`
 ![BorderBackground](images/activeScopeBackground.png "Active Scope Background Example")
 
 > `"bracket-pair-colorizer-2.showBracketsInGutter"`  


### PR DESCRIPTION
Since I struggled to find how to recreate the opacity setting for the coloring of the activeScope brackets as shown in the image in the readme, I edited the readme to reflect the solution for this. It will help users with the same question to find the solution more easily than having to dig through the 'Issues' section