### PR TITLE
Clarify allowed bracket colors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Screenshot:
 ## Settings
 
 > `"bracket-pair-colorizer-2.colors"`  
-Define the colors used to colorize brackets. Accepts valid color names, hex codes, and `rgba()` values.
+Define the colors used to colorize brackets. Accepts [CSS3 color values](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) - valid color names, hex codes, `rgb()` and `hsl()` values. 
 ```json
 "bracket-pair-colorizer-2.colors": [
     "Gold",


### PR DESCRIPTION
As you can see in issue #176 - allowed bracket color values need some clarification.

Feel free to rephrase it.