### PR TITLE
Slight refactor of `TextLine`

### DIFF
--- a/src/documentDecoration.ts
+++ b/src/documentDecoration.ts
@@ -59,7 +59,7 @@ export default class DocumentDecoration {
 
         // Current line has new brackets which need to be colored
         if (
-            !currentLine.getRuleStack().equals(newLine.getRuleStack()) ||
+            !currentLine.ruleStack.equals(newLine.ruleStack) ||
             currentLine.getBracketHash() !== newLine.getBracketHash()
         ) {
             this.lines[lineNumber] = newLine;
@@ -308,7 +308,7 @@ export default class DocumentDecoration {
     private tokenizeLine(index: number) {
         const newText = this.document.lineAt(index).text;
         const previousLineRuleStack = index > 0 ?
-            this.lines[index - 1].getRuleStack() :
+            this.lines[index - 1].ruleStack :
             undefined;
 
         const previousLineState = index > 0 ?
@@ -341,7 +341,7 @@ export default class DocumentDecoration {
         for (const match of matches) {
             const lookup = this.languageConfig.bracketToId.get(match.content);
             if (lookup) {
-                newLine.AddToken(match.content, match.index, lookup.key, lookup.open);
+                newLine.addToken(match.content, match.index, lookup.key, lookup.open);
             }
         }
         return newLine;

--- a/src/textLine.ts
+++ b/src/textLine.ts
@@ -5,9 +5,10 @@ import { IStackElement } from "./IExtensionGrammar";
 import LineState from "./lineState";
 
 export default class TextLine {
-    public index: number;
-    private lineState: LineState;
-    private readonly ruleStack: IStackElement;
+    public readonly ruleStack: IStackElement;
+
+    private readonly index: number;
+    private readonly lineState: LineState;
 
     constructor(
         ruleStack: IStackElement,
@@ -16,10 +17,6 @@ export default class TextLine {
         this.lineState = lineState;
         this.ruleStack = ruleStack;
         this.index = index;
-    }
-
-    public getRuleStack(): IStackElement {
-        return this.ruleStack;
     }
 
     // Return a copy of the line while mantaining bracket state. colorRanges is not mantained.
@@ -31,7 +28,7 @@ export default class TextLine {
         return this.lineState.getBracketHash();
     }
 
-    public AddToken(
+    public addToken(
         currentChar: string,
         index: number,
         key: number,


### PR DESCRIPTION
- `ruleStack` is readonly, so no need for a getter
- Make `lineState` readonly
- Correct capitalization of `AddToken()`