### PR TITLE
Allow bracket pairs to share open tokens or close tokens

### DIFF
--- a/src/documentDecoration.ts
+++ b/src/documentDecoration.ts
@@ -342,7 +342,7 @@ export default class DocumentDecoration {
         for (const match of matches) {
             const lookup = this.languageConfig.bracketToId.get(match.content);
             if (lookup) {
-                newLine.AddToken(match.content, match.index, lookup.key, lookup.open);
+                newLine.AddToken(match.content, match.index, lookup.key, lookup.open, lookup.pairsWith);
             }
         }
         return newLine;

--- a/src/languageConfig.ts
+++ b/src/languageConfig.ts
@@ -3,9 +3,9 @@ import { IGrammar } from "./IExtensionGrammar";
 export default class LanguageConfig {
     public readonly grammar: IGrammar;
     public readonly regex: RegExp;
-    public readonly bracketToId: Map<string, { open: boolean, key: number }>;
+    public readonly bracketToId: Map<string, { open: boolean, key: number, pairsWith: Array<number> }>;
 
-    constructor(grammar: IGrammar, regex: RegExp, bracketToId: Map<string, { open: boolean, key: number }>) {
+    constructor(grammar: IGrammar, regex: RegExp, bracketToId: Map<string, { open: boolean, key: number, pairsWith: Array<number> }>) {
         this.grammar = grammar;
         this.regex = regex;
         this.bracketToId = bracketToId;

--- a/src/lineState.ts
+++ b/src/lineState.ts
@@ -66,8 +66,9 @@ export default class LineState {
         beginIndex: number,
         lineIndex: number,
         open: boolean,
+        pairsWith: Array<number>
     ) {
-        const token = new Token(type, character, beginIndex, lineIndex);
+        const token = new Token(type, character, beginIndex, lineIndex, pairsWith);
         if (open) {
             this.addOpenBracket(token);
         }

--- a/src/multipleIndexes.ts
+++ b/src/multipleIndexes.ts
@@ -56,7 +56,7 @@ export default class MultipleBracketGroups implements IBracketManager {
         const openStack = this.allLinesOpenBracketStack[token.type];
 
         if (openStack.length > 0) {
-            if (openStack[openStack.length - 1].token.type === token.type) {
+            if (openStack[openStack.length - 1].token.pairsWith.indexOf(token.type) >= 0) {
                 const openBracket = openStack.pop();
                 const closeBracket = new BracketClose(token, openBracket!);
                 this.allBracketsOnLine.push(closeBracket);

--- a/src/singularIndex.ts
+++ b/src/singularIndex.ts
@@ -49,7 +49,7 @@ export default class SingularBracketGroup implements IBracketManager {
 
     public addCloseBracket(token: Token) {
         if (this.allLinesOpenBracketStack.length > 0) {
-            if (this.allLinesOpenBracketStack[this.allLinesOpenBracketStack.length - 1].token.type === token.type) {
+            if (this.allLinesOpenBracketStack[this.allLinesOpenBracketStack.length - 1].token.pairsWith.indexOf(token.type) >= 0) {
                 const openBracket = this.allLinesOpenBracketStack.pop();
                 const closeBracket = new BracketClose(token, openBracket!);
                 this.allBracketsOnLine.push(closeBracket);

--- a/src/textLine.ts
+++ b/src/textLine.ts
@@ -36,8 +36,9 @@ export default class TextLine {
         index: number,
         key: number,
         open: boolean,
+        pairsWith: Array<number>
     ) {
-        this.lineState.addBracket(key, currentChar, index, this.index, open);
+        this.lineState.addBracket(key, currentChar, index, this.index, open, pairsWith);
     }
 
     public getClosingBracket(position: Position): BracketClose | undefined {

--- a/src/textMateLoader.ts
+++ b/src/textMateLoader.ts
@@ -91,11 +91,30 @@ export class TextMateLoader {
                             return;
                         }
 
-                        const bracketToId = new Map<string, { open: boolean, key: number }>();
+                        const bracketToId = new Map<string, { open: boolean, key: number, pairsWith: Array<number> }>();
                         for (let i = 0; i < brackets.length; i++) {
                             const bracket = brackets[i];
-                            bracketToId.set(bracket[0], { open: true, key: i });
-                            bracketToId.set(bracket[1], { open: false, key: i });
+
+                            var openBracket = bracketToId.get(bracket[0]);
+                            var closeBracket = bracketToId.get(bracket[1]);
+
+                            // Create new keys if brackets don't exist.
+                            if (openBracket === undefined) {
+                                openBracket = { open: true, key: i, pairsWith: [] };
+                            }
+                            if (closeBracket === undefined) {
+                                closeBracket = { open: false, key: i, pairsWith: [] };
+                            }
+                            // Link open and close brackets.
+                            if (openBracket.pairsWith.indexOf(closeBracket.key) < 0) {
+                                openBracket.pairsWith.push(closeBracket.key);
+                            }
+                            if (closeBracket.pairsWith.indexOf(openBracket.key) < 0) {
+                                closeBracket.pairsWith.push(openBracket.key);
+                            }
+                            // Create or update bracket definitions
+                            bracketToId.set(bracket[0], openBracket);
+                            bracketToId.set(bracket[1], closeBracket);
                         }
 
                         let maxBracketLength = 0;

--- a/src/token.ts
+++ b/src/token.ts
@@ -2,11 +2,13 @@ import { Position, Range } from "vscode";
 
 export default class Token {
     public readonly type: number;
+    public readonly pairsWith: Array<number>;
     public readonly character: string;
     public range: Range;
 
-    constructor(type: number, character: string, beginIndex: number, lineIndex: number) {
+    constructor(type: number, character: string, beginIndex: number, lineIndex: number, pairsWith: Array<number>) {
         this.type = type;
+        this.pairsWith = pairsWith;
         this.character = character;
         const startPos = new Position(lineIndex, beginIndex);
         const endPos = startPos.translate(0, character.length);


### PR DESCRIPTION
This addresses issue #301. Initial testing allows the Verilog `case` and `endcase` tokens to match correctly, and doesn't seem to break any other files I opened.

This modification does three things:
1. Adds `pairsWith` to `Token` and everything that instantiates tokens.
2. When loading the textmate languages, braces are still only added once to the map, but `pairsWith` is now used to keep track of which open braces have been paired with which closing braces, to allow one-to-many associations.
3. In `AddCloseBracket`, the open brace checks its `pairsWith` list to determine if the close bracket should be a match, instead of checking for like keys.