### PR TITLE
Theme colors for brackets and unmatched scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Screenshot:
 ## Settings
 
 > `"bracket-pair-colorizer-2.colors"`  
-Define the colors used to colorize brackets. Accepts valid color names, hex codes, and `rgba()` values.
+Define the colors used to colorize brackets. Accepts valid color names, hex codes, and `rgba()` values. Colors `bracketPairColorizer2.bracketColorN` (N=1..5) are theme colors specific to this extension. These can be configured in `workbench.colorCustomizations` and allow for theme-aware (e.g. dark/light) customization.
 ```json
 "bracket-pair-colorizer-2.colors": [
     "Gold",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
               "defaults": {
                 "dark": "#ffdf00",
                 "light": "#ffdf00",
-                "highContrast": "#010203"
+                "highContrast": "#ffe600"
               }
             },
             {
@@ -58,7 +58,7 @@
               "defaults": {
                 "dark": "#da70d6",
                 "light": "#da70d6",
-                "highContrast": "#010203"
+                "highContrast": "#ff00ff"
               }
             },
             {
@@ -67,16 +67,16 @@
               "defaults": {
                 "dark": "#87cefa",
                 "light": "#87cefa",
-                "highContrast": "#010203"
+                "highContrast": "#00ff00"
               }
             },
             {
               "id": "bracketPairColorizer2.bracketColor4",
               "description": "Bracket color #4. Can be used in bracket-pair-colorizer-2.colors for theme-based color custimization.",
               "defaults": {
-                "dark": "#0000FF",
-                "light": "#0000FF",
-                "highContrast": "#010203"
+                "dark": "#0000ff",
+                "light": "#0000ff",
+                "highContrast": "#00ffff"
               }
             },
             {
@@ -85,7 +85,7 @@
               "defaults": {
                 "dark": "#008000",
                 "light": "#008000",
-                "highContrast": "#010203"
+                "highContrast": "#ffffff"
               }
             },
             {
@@ -94,7 +94,7 @@
               "defaults": {
                 "dark": "#ff0000",
                 "light": "#ff0000",
-                "highContrast": "#010203"
+                "highContrast": "#ff0000"
               }
             }
         ],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,62 @@
                 "title": "Undo Bracket Selection"
             }
         ],
+        "colors": [
+            {
+              "id": "bracketPairColorizer2.bracketColor1",
+              "description": "Bracket color #1. Can be used in bracket-pair-colorizer-2.colors for theme-based color custimization.",
+              "defaults": {
+                "dark": "#ffdf00",
+                "light": "#ffdf00",
+                "highContrast": "#010203"
+              }
+            },
+            {
+              "id": "bracketPairColorizer2.bracketColor2",
+              "description": "Bracket color #2. Can be used in bracket-pair-colorizer-2.colors for theme-based color custimization.",
+              "defaults": {
+                "dark": "#da70d6",
+                "light": "#da70d6",
+                "highContrast": "#010203"
+              }
+            },
+            {
+              "id": "bracketPairColorizer2.bracketColor3",
+              "description": "Bracket color #3. Can be used in bracket-pair-colorizer-2.colors for theme-based color custimization.",
+              "defaults": {
+                "dark": "#87cefa",
+                "light": "#87cefa",
+                "highContrast": "#010203"
+              }
+            },
+            {
+              "id": "bracketPairColorizer2.bracketColor4",
+              "description": "Bracket color #4. Can be used in bracket-pair-colorizer-2.colors for theme-based color custimization.",
+              "defaults": {
+                "dark": "#0000FF",
+                "light": "#0000FF",
+                "highContrast": "#010203"
+              }
+            },
+            {
+              "id": "bracketPairColorizer2.bracketColor5",
+              "description": "Bracket color #5. Can be used in bracket-pair-colorizer-2.colors for theme-based color custimization.",
+              "defaults": {
+                "dark": "#008000",
+                "light": "#008000",
+                "highContrast": "#010203"
+              }
+            },
+            {
+              "id": "bracketPairColorizer2.unmatchedScopeColor",
+              "description": "Unmatched scope color. Can be used in bracket-pair-colorizer-2.unmatchedScopeColor for theme-based color custimization.",
+              "defaults": {
+                "dark": "#ff0000",
+                "light": "#ff0000",
+                "highContrast": "#010203"
+              }
+            }
+        ],
         "configuration": {
             "type": "object",
             "title": "Bracket Pair Colorizer 2",


### PR DESCRIPTION
Added VSCode theme colours for brackets and unmatched scope via _contributes.colors_ to allow per-theme customisation (e.g. different colours for dark / light themes). Colours are named `bracketPairColorizer2.bracketColor1` through `.bracketColor5`, and `.unmatchedScopeColor`. These can be referred to in the respective bracket-pair-colorizer-2 settings.

Changes affect Package.json, and the readme was updated as well. However, unmatched scope colour was not originally mentioned in the readme and I left it that way.