### PR TITLE
Fix issue with loadWASM already being called

### DIFF
--- a/src/textMateLoader.ts
+++ b/src/textMateLoader.ts
@@ -129,7 +129,11 @@ export class TextMateLoader {
         const oniguruma = this.getNodeModule("vscode-oniguruma");
         const wasmPath = path.join(this.getNodeModulePath("vscode-oniguruma"), 'release', 'onig.wasm');
         const onigurumaWasm = fs.readFileSync(wasmPath).buffer;
-        oniguruma.loadWASM(onigurumaWasm);
+        try {
+          oniguruma.loadWASM(onigurumaWasm); // Catch loadWASM already called
+        } catch (error) {
+          console.warn(error) // Warn out instead of erroring
+        }
         return oniguruma;
     }
 


### PR DESCRIPTION
I have added a try/catch for oniguruma loadWASM to catch the already loaded issue.
Oniguruma does not look like it has any public available way of detecting if loadWASM has already been called, instead relying on a private variable.
see: https://github.com/microsoft/vscode-oniguruma/blob/a2345d7fa36529cffaee10ecaed0f85b9dc7a1f4/src/index.ts#L378 