### PR TITLE
Adds deprecation notice to extension title.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bracket-pair-colorizer-2",
-    "displayName": "Bracket Pair Colorizer 2",
+    "displayName": "[Deprecated] Bracket Pair Colorizer 2",
     "description": "A customizable extension for colorizing matching brackets",
     "version": "0.2.2",
     "publisher": "CoenraadS",


### PR DESCRIPTION
Hey there 😉

Thanks for putting the deprecation notice in your readme and for implementing the notification to prompt users to migrate to the native feature!

However, we still notice that many users install your extension.
Unfortunately, the VS Code marketplace has no mechanism of properly deprecating an extension yet.
Thus, we recommend to prepend the extension title with `[Deprecation]`, so that even though your extension appears in the list of the most popular extensions, users can see immediately that it is deprecated.

I prepared this PR to help you with this, but we also understand if you like to keep your current extension name without the deprecation notice.

Thanks!